### PR TITLE
XML Fixes

### DIFF
--- a/Data/Config/entityclasses.xml
+++ b/Data/Config/entityclasses.xml
@@ -762,9 +762,9 @@
         <drop event="Harvest" name="Hoof" tool_category="Butcher" count="2" prob=".4" />
         <drop event="Harvest" name="Hoof" tool_category="Butcher" count="2" prob=".4" />
 		<drop event="Harvest" name="BrainMatter" tool_category="Butcher" count="9" />
-        <drop event="Harvest" name="VenisonTenderloin" tool_category="Hunter" count="1" />
-        <drop event="Harvest" name="VenisonTenderloin" tool_category="Hunter" count="1" prob=".2" />
-        <drop event="Harvest" name="VenisonTenderloin" tool_category="Hunter" count="1" prob=".2" />
+        <drop event="Harvest" name="VenisonTenderloin" tool_category="Butcher" count="1" />
+        <drop event="Harvest" name="VenisonTenderloin" tool_category="Butcher" count="1" prob=".2" />
+        <drop event="Harvest" name="VenisonTenderloin" tool_category="Butcher" count="1" prob=".2" />
         <!--JZMOD Destroy-->
         <drop event="Destroy" name="femur"  count="2" />
         <drop event="Destroy" name="femur" tool_category="Hunter" count="2" />

--- a/Data/Config/recipes.xml
+++ b/Data/Config/recipes.xml
@@ -2038,7 +2038,7 @@ Unfortunately auto-calc only seems to work on the first (top) ingredient in the 
 	<ingredient name="stick" count="2"/>
 </recipe>
 
-<recipe name="spotlight" count="1" craft_area="workworkbench" craft_tool="wrench" craft_time="10" craft_exp_gain="10">
+<recipe name="spotlight" count="1" craft_area="workMetalWorkBench" craft_tool="wrench" craft_time="10" craft_exp_gain="10">
 	<ingredient name="headlight" count="1"/>
     <ingredient name="cntTrash_can01" count="1" />
     <ingredient name="carBattery" count="1"/>


### PR DESCRIPTION
Venison Tenderloin can now drop from butcher class tools like Field
Knife (likely a copy/paste error).

Spotlight craft_area changed to workMetalWorkBench to match the wrench
requirement.